### PR TITLE
added new item to Websocket section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,7 @@ Inspired by [fucking-awesome-go](https://github.com/hvnsweeting/fucking-awesome-
 * [:octocat: autobahn-python](https://github.com/crossbario/autobahn-python) - :star: 2223 :fork_and_knife: 620 - WebSocket & WAMP for Python on Twisted and [asyncio](https://docs.python.org/3/library/asyncio.html).
 * [:octocat: channels](https://github.com/django/channels) - :star: 4632 :fork_and_knife: 640 - Developer-friendly asynchrony for Django.
 * [:octocat: websockets](https://github.com/aaugustin/websockets) - :star: 3007 :fork_and_knife: 343 - A library for building WebSocket servers and clients with a focus on correctness and simplicity.
+* [:octocat: WSocket](https://github.com/Ksengine/wsocket) - :star: 3 :fork_and_knife: 1 - Simple WSGI HTTP + Websocket - Server, Framework, Middleware(Websocket for any WSGI framework) And App.
 
 ## WSGI Servers
 


### PR DESCRIPTION
# added [WSocket](https://github.com/Ksengine/wsocket) to list

## Simple WSGI HTTP + Websocket Server, Framework, Middleware And App.

## Includes
- Server(WSGI) included - works with any WSGI framework
- Middleware - adds Websocket support for any  WSGI framework
- Framework - simple Websocket WSGI web application framework
- App - Event based app for Websocket communication
**When external server used some clients like Firefox requires `http 1.1` Server. Middleware, Framework, App**
- Handler - adds Websocket support to [wsgiref](https://docs.python.org/3/library/wsgiref.html "python builtin WSGI server")(python builtin WSGI server)
- Client -Coming soon...

## Common Features

- only single file less than 1000 lines
- websocket sub protocol supported
- websocket message compression supported (works if client asks)
- receive and send pong and ping messages(with automatic pong sender)
- receive and send binary or text messages
- works for messages with or without mask
- closing messages supported
- auto and manual close

## Alternatives
### Non WSGI
- [Autobahn](http://crossbar.io/autobahn/) - huge with extras
- [websocket-client](https://github.com/websocket-client/websocket-client) - client only no server
-[websockets](https://pypi.org/project/websockets/) - python2 not supported

### WSGI
- [Django Channels](https://channels.readthedocs.io/en/stable/) - only for Django. but WSocket middleware can add support for any WSGI framework.
- [Flask-SocketIO](https://flask-socketio.readthedocs.io/en/latest/) - only for Flask.
- [gevent-websocket](https://pypi.org/project/gevent-websocket/) - only for Gevent Server
- [ws4py](https://github.com/Lawouach/WebSocket-for-Python) - works with few servers. but WSocket works with many servers